### PR TITLE
MIST-150 Create and Delete recursive snapshot response

### DIFF
--- a/snapshot.go
+++ b/snapshot.go
@@ -109,7 +109,8 @@ func (store *ImageStore) getSnapshotsRecursive(id string) ([]*zfs.Dataset, error
 
 	snapName := splitID[1]
 	for i := range datasets {
-		if snapName == strings.Split(datasets[i].Name, "@")[1] {
+		parts := strings.Split(datasets[i].Name, "@")
+		if len(parts) == 2 && snapName == parts[1] {
 			results = append(results, datasets[i])
 		}
 	}


### PR DESCRIPTION
Create and Delete respond with an array of snapshots affected. Previously, when called with the recursive flag, the array only contained the parent's snapshot, regardless of whether any descendent snapshots were touched. Now it returns an array of all affected snapshots for recursive actions.

Additionally, this creates a common method to format the snapshots response array from a set of datasets, which replaces some code in the List method as well.
