### PR TITLE
MIST-189 Prepend the zpool to request ids and update snapshot tests

### DIFF
--- a/cmd/mistify-agent-image/main.go
+++ b/cmd/mistify-agent-image/main.go
@@ -15,7 +15,7 @@ func main() {
 
 	flag.BoolVar(&h, []string{"h", "#help", "-help"}, false, "display the help")
 	flag.IntVar(&port, []string{"p", "#port", "-port"}, 19999, "listen port")
-	flag.StringVar(&zpool, []string{"z", "#zpool", "-zpool"}, "guests", "zpool")
+	flag.StringVar(&zpool, []string{"z", "#zpool", "-zpool"}, "mistify", "zpool")
 	flag.StringVar(&logLevel, []string{"l", "-log-level"}, "warning", "log level: debug/info/warning/error/critical/fatal")
 	flag.Parse()
 

--- a/snapshot.go
+++ b/snapshot.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -41,7 +42,8 @@ func (store *ImageStore) CreateSnapshot(r *http.Request, request *rpc.SnapshotRe
 		return errors.New("need an id")
 	}
 
-	ds, err := zfs.GetDataset(request.Id)
+	fullId := filepath.Join(store.config.Zpool, request.Id)
+	ds, err := zfs.GetDataset(fullId)
 	if err != nil {
 		if isZfsNotFound(err) {
 			return NotFound
@@ -86,7 +88,8 @@ func (store *ImageStore) CreateSnapshot(r *http.Request, request *rpc.SnapshotRe
 }
 
 func (store *ImageStore) getSnapshot(id string) (*zfs.Dataset, error) {
-	ds, err := zfs.GetDataset(id)
+	fullId := filepath.Join(store.config.Zpool, id)
+	ds, err := zfs.GetDataset(fullId)
 	if err != nil {
 		if isZfsNotFound(err) {
 			return nil, NotFound
@@ -197,12 +200,8 @@ ListSnapshots retrieves a list of all snapshots for a dataset.
     id        string :     : Dataset to list snapshots for
 */
 func (store *ImageStore) ListSnapshots(r *http.Request, request *rpc.SnapshotRequest, response *rpc.SnapshotResponse) error {
-	filter := store.config.Zpool
-	if request.Id != "" {
-		filter = request.Id
-	}
-
-	datasets, err := zfs.Snapshots(filter)
+	fullId := filepath.Join(store.config.Zpool, request.Id)
+	datasets, err := zfs.Snapshots(fullId)
 	if err != nil {
 		if isZfsNotFound(err) {
 			return NotFound

--- a/volume.go
+++ b/volume.go
@@ -48,7 +48,8 @@ func (store *ImageStore) CreateVolume(r *http.Request, request *rpc.VolumeReques
 		return errors.New("need an id")
 	}
 
-	ds, err := zfs.CreateVolume(request.Id, request.Size*1024*1024, default_zfs_options)
+	fullId := filepath.Join(store.config.Zpool, request.Id)
+	ds, err := zfs.CreateVolume(fullId, request.Size*1024*1024, default_zfs_options)
 	if err != nil {
 		return err
 	}
@@ -63,7 +64,8 @@ func (store *ImageStore) CreateVolume(r *http.Request, request *rpc.VolumeReques
 }
 
 func (store *ImageStore) GetVolume(r *http.Request, request *rpc.VolumeRequest, response *rpc.VolumeResponse) error {
-	ds, err := zfs.GetDataset(request.Id)
+	fullId := filepath.Join(store.config.Zpool, request.Id)
+	ds, err := zfs.GetDataset(fullId)
 	if err != nil {
 		return err
 	}
@@ -81,7 +83,8 @@ func (store *ImageStore) DeleteDataset(r *http.Request, request *rpc.VolumeReque
 	if request.Id == "" {
 		return errors.New("need an id")
 	}
-	ds, err := zfs.GetDataset(request.Id)
+	fullId := filepath.Join(store.config.Zpool, request.Id)
+	ds, err := zfs.GetDataset(fullId)
 	if err != nil {
 	}
 


### PR DESCRIPTION
So the requesting client (e.g. core agent) doesn't need to care about zpools when requesting resources, have the image sub agent prepend the zpool it was started with to parameter ids before acting.

Also some test cleanup for snapshots so everything isn't hardcoded.
