### PR TITLE
MIST-199 Use gopkg.in for importing a versioned go-zfs. Currently v1.

### DIFF
--- a/clone.go
+++ b/clone.go
@@ -2,7 +2,8 @@ package imagestore
 
 import (
 	"fmt"
-	"github.com/mistifyio/go-zfs"
+
+	"gopkg.in/mistifyio/go-zfs.v1"
 )
 
 type (

--- a/fetch.go
+++ b/fetch.go
@@ -3,12 +3,13 @@ package imagestore
 import (
 	"compress/gzip"
 	"fmt"
-	"github.com/mistifyio/go-zfs"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
+
+	"gopkg.in/mistifyio/go-zfs.v1"
 )
 
 type (

--- a/image.go
+++ b/image.go
@@ -2,11 +2,12 @@ package imagestore
 
 import (
 	"errors"
-	"github.com/mistifyio/go-zfs"
-	"github.com/mistifyio/kvite"
-	"github.com/mistifyio/mistify-agent/rpc"
 	"net/http"
 	"strings"
+
+	"github.com/mistifyio/kvite"
+	"github.com/mistifyio/mistify-agent/rpc"
+	"gopkg.in/mistifyio/go-zfs.v1"
 )
 
 type ()

--- a/snapshot.go
+++ b/snapshot.go
@@ -8,8 +8,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/mistifyio/go-zfs"
 	"github.com/mistifyio/mistify-agent/rpc"
+	"gopkg.in/mistifyio/go-zfs.v1"
 )
 
 var validName = regexp.MustCompile(`^[a-zA-Z0-9_\-:\.]+$`)

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -11,9 +11,9 @@ import (
 	"time"
 
 	"github.com/bakins/test-helpers"
-	"github.com/mistifyio/go-zfs"
 	"github.com/mistifyio/mistify-agent-image"
 	"github.com/mistifyio/mistify-agent/rpc"
+	"gopkg.in/mistifyio/go-zfs.v1"
 )
 
 var default_zfs_options map[string]string = map[string]string{

--- a/store.go
+++ b/store.go
@@ -16,10 +16,10 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/mistifyio/go-zfs"
 	"github.com/mistifyio/kvite"
 	"github.com/mistifyio/mistify-agent/client"
 	"github.com/mistifyio/mistify-agent/rpc"
+	"gopkg.in/mistifyio/go-zfs.v1"
 )
 
 const (

--- a/volume.go
+++ b/volume.go
@@ -2,10 +2,11 @@ package imagestore
 
 import (
 	"errors"
-	"github.com/mistifyio/go-zfs"
-	"github.com/mistifyio/mistify-agent/rpc"
 	"net/http"
 	"path/filepath"
+
+	"github.com/mistifyio/mistify-agent/rpc"
+	"gopkg.in/mistifyio/go-zfs.v1"
 )
 
 type ()

--- a/volume_test.go
+++ b/volume_test.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"github.com/bakins/test-helpers"
-	"github.com/mistifyio/go-zfs"
 	"github.com/mistifyio/mistify-agent-image"
 	"github.com/mistifyio/mistify-agent/rpc"
+	"gopkg.in/mistifyio/go-zfs.v1"
 )
 
 func pow2(x int) int64 {


### PR DESCRIPTION
Lots of changes coming to go-zfs. Lock down the version of go-zfs that we're using.
